### PR TITLE
Bump base to <5 for GHC 8.10

### DIFF
--- a/prim-instances.cabal
+++ b/prim-instances.cabal
@@ -33,7 +33,7 @@ library
   exposed-modules:
     Data.Primitive.Instances
   build-depends:
-    , base >=4.7 && <4.14
+    , base >=4.7 && <5
     , primitive >= 0.6.4 && < 0.8
   hs-source-dirs:
     src


### PR DESCRIPTION
Hopefully `prim-instances` will make it into `primitive` itself at some point. For now, though, this builds fine on 8.10, and the base constraint blocks a couple of other things from building on 8.10.